### PR TITLE
Adding a 'filter' parameter to limit what will be synced. (Take 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,19 @@ resources:
     access_key_id: {{aws-access-key}}
     secret_access_key: {{aws-secret-key}}
     bucket: {{aws-bucket}}
+    filter: <optional, see note below>
 jobs:
 - name: <job name>
   plan:
   - <some Resource or Task that outputs files>
   - put: <resource name>
 ```
+
+The `filter` parameter defines a filter for files that will be synced with S3. Leaving it out will sync the working directory. A few examples:
+
+* Setting it to `results/*` will only sync the contents of the `results` directory.
+
+* Setting it to `*.json` will sync all JSON files in the root directory.
 
 See [the instructions for getting your AWS credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup), then pass them and the bucket name in as [parameters](http://concourse.ci/fly-set-pipeline.html#section_parameters).
 

--- a/assets/in
+++ b/assets/in
@@ -19,6 +19,7 @@ fi
 # parse incoming config data
 payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
+filter=$(echo "$payload" | jq -r '.source.filter')
 
 
 echo "Downloading from S3..."
@@ -27,9 +28,14 @@ echo "Downloading from S3..."
 export AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
 export AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
 
-aws s3 sync "s3://$bucket" $dest
+filters=''
+if [[ "$filter" != "null" ]]
+then
+  filters="--exclude '*' --include \"$filter\""
+fi
+
+eval aws s3 sync "s3://$bucket" $dest $filters
 
 echo "...done."
-
 
 source "$(dirname $0)/emit.sh" >&3

--- a/assets/out
+++ b/assets/out
@@ -20,6 +20,7 @@ fi
 # parse incoming config data
 payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
+filter=$(echo "$payload" | jq -r '.source.filter')
 
 
 echo "Uploading to S3..."
@@ -28,7 +29,13 @@ echo "Uploading to S3..."
 export AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
 export AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
 
-aws s3 sync $source "s3://$bucket"
+filters=''
+if [[ "$filter" != "null" ]]
+then
+  filters="--exclude '*' --include \"$filter\""
+fi
+
+eval aws s3 sync $source "s3://$bucket" $filters
 
 echo "...done."
 

--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
   "source": {
     "access_key_id": "",
     "secret_access_key": "",
-    "bucket": ""
+    "bucket": "",
+    "filter": ""
   }
 }


### PR DESCRIPTION
The filter parameter is optional, but it (or something like it) is needed to limit what is pulled down from S3. By default the sync operation syncs the working directory which, for us, also syncs the scripts folder. This could result in some squirrelly behavior if we get the last put'd script directory.

This is a re-creation of #2 from a branch instead of my fork to make it easier for others (hi, @ctro) to work on.