### PR TITLE
Support AWS IAM Roles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ jobs:
   - put: <resource name>
 ```
 
+## AWS Credentials
+
+The `access_key_id` and `secret_access_key` are optional and if not provided the EC2 Metadata service will be queried for role based credentials.
+
 ## Options
 
 The `options` parameter is synonymous with the options that `aws cli` accepts for `sync`. Please see [S3 Sync Options](http://docs.aws.amazon.com/cli/latest/reference/s3/sync.html#options) and pay special attention to the [Use of Exclude and Include Filters](http://docs.aws.amazon.com/cli/latest/reference/s3/index.html#use-of-exclude-and-include-filters).

--- a/assets/check
+++ b/assets/check
@@ -9,8 +9,14 @@ payload=`cat`
 bucket=$(echo "$payload" | jq -r '.source.bucket')
 
 # export for `aws` cli
-export AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-export AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+
+# Due to precedence rules, must be unset to support AWS IAM Roles.
+if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
+  export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+fi
 
 # Consider the most recent LastModified timestamp as the most recent version.
 timestamps="$(aws s3api list-objects --bucket $bucket --query 'Contents[].{LastModified: LastModified}')"

--- a/assets/in
+++ b/assets/in
@@ -20,8 +20,14 @@ bucket=$(echo "$payload" | jq -r '.source.bucket')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 
 # export for `aws` cli
-export AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-export AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+
+# Due to precedence rules, must be unset to support AWS IAM Roles.
+if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
+  export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+fi
 
 echo "Downloading from S3..."
 eval aws s3 sync "s3://$bucket" $dest $options

--- a/assets/out
+++ b/assets/out
@@ -20,8 +20,14 @@ bucket=$(echo "$payload" | jq -r '.source.bucket')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 
 # export for `aws` cli
-export AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-export AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+
+# Due to precedence rules, must be unset to support AWS IAM Roles.
+if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
+  export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+fi
 
 echo "Uploading to S3..."
 eval aws s3 sync $source "s3://$bucket" $options


### PR DESCRIPTION
Only define credential environment variables when values have been passed through. Assigning them to empty values enacts the AWS credential precedence rules and the Role will never be utilised through metadata.

Addresses #8 

## Testing

With regards to testing, open to ideas to test the absence of credentials on a docker image that would mimic a role and access to AWS metadata which you don't have access to in local development.

I have tested this running in Concourse and as stated, if the credential environment variables are not set, then it will gain access through keys retrieved from the metadata service.