### PR TITLE
Remove colons from options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ we can upload _only_ the `results` subdirectory by using the following `options`
 
 ```yaml
 options:
-  - "--exclude: '*'",
-  - "--include: 'results/*'"
+  - "--exclude '*'",
+  - "--include 'results/*'"
 ```


### PR DESCRIPTION
Colons were causing errors during upload.