### PR TITLE
Add optional parameter to specify AWS region

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ resources:
     bucket: {{aws-bucket}}
     path: [<optional>, use to sync to a specific path of the bucket instead of root of bucket]
     options: [<optional, see note below>]
+    region: <optional, see below>
 jobs:
 - name: <job name>
   plan:
@@ -53,4 +54,13 @@ we can upload _only_ the `results` subdirectory by using the following `options`
 options:
   - "--exclude '*'",
   - "--include 'results/*'"
+```
+
+### Region
+Interacting with some AWS regions (like London) requires AWS Signature Version
+4. This options allows you to explicitly specify region where your bucket is
+located (if this is set, AWS_DEFAULT_REGION env variable will be set accordingly).
+
+```yaml
+region: eu-west-2
 ```

--- a/assets/check
+++ b/assets/check
@@ -10,9 +10,9 @@ bucket=$(echo "$payload" | jq -r '.source.bucket')
 prefix="$(echo "$payload" | jq -r '.source.path // ""')"
 
 # export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
-AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
+AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region // empty')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then

--- a/assets/check
+++ b/assets/check
@@ -12,12 +12,16 @@ prefix="$(echo "$payload" | jq -r '.source.path // ""')"
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
 AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
   export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
   export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 fi
+
+# Export AWS_DEFAULT_REGION if set
+[ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 # Consider the most recent LastModified timestamp as the most recent version.
 timestamps=$(aws s3api list-objects --bucket $bucket --prefix "$prefix" --query 'Contents[].{LastModified: LastModified}')

--- a/assets/in
+++ b/assets/in
@@ -23,12 +23,16 @@ options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
 AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
   export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
   export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 fi
+
+# Export AWS_DEFAULT_REGION if set
+[ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 echo "Downloading from S3..."
 eval aws s3 sync "s3://$bucket/$path" $dest $options

--- a/assets/in
+++ b/assets/in
@@ -21,9 +21,9 @@ path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 
 # export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
-AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
+AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region // empty')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then

--- a/assets/out
+++ b/assets/out
@@ -23,12 +23,16 @@ options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
 AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
   export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
   export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 fi
+
+# Export AWS_DEFAULT_REGION if set
+[ -n "$AWS_DEFAULT_REGION" ] && export AWS_DEFAULT_REGION
 
 echo "Uploading to S3..."
 eval aws s3 sync $source "s3://$bucket/$path" $options

--- a/assets/out
+++ b/assets/out
@@ -21,9 +21,9 @@ path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 
 # export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
-AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // empty')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // empty')
+AWS_DEFAULT_REGION=$(echo "$payload" | jq -r '.source.region // empty')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then


### PR DESCRIPTION
This PR includes 2 things:
- Support for specifying region
- Fix when using IAM role for credentials

Interacting with some AWS regions (like London) requires AWS Signature Version 4. This new `region` option allows you to explicitly specify region where your bucket is located (if this is set, AWS_DEFAULT_REGION env variable will be set accordingly).

Currently the resource fails with following error (in case of region requiring V4 signature):
```
An error occurred (InvalidRequest) when calling the ListObjects operation: You are attempting to operate on a bucket in a region that requires Signature Version 4.  You can fix this issue by explicitly providing the correct region location using the --region argument, the AWS_DEFAULT_REGION environment variable, or the region variable in the AWS CLI configuration file.  You can get the bucket's location by running "aws s3api get-bucket-location --bucket BUCKET".
```

This PR also fixes error when trying to use IAM roles (instead of credentials in form of parameters) - problem is that `jq` returns `"null"`, while the shell scripts are expecting empty string `""`.