### PR TITLE
Add option to skip downloading

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -20,6 +20,8 @@ bucket=$(echo "$payload" | jq -r '.source.bucket')
 path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 
+skip_download=$(echo "$payload" | jq -r '.params.skip_download // ""')
+
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
 AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
@@ -30,8 +32,12 @@ if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
   export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 fi
 
-echo "Downloading from S3..."
-eval aws s3 sync "s3://$bucket/$path" $dest $options
-echo "...done."
+if [ "$skip_download" = "true" ]; then
+  echo "Skipping downloading from S3..."
+else
+  echo "Downloading from S3..."
+  eval aws s3 sync "s3://$bucket/$path" $dest $options
+  echo "...done."
+fi
 
 source "$(dirname $0)/emit.sh" >&3


### PR DESCRIPTION
Similar to https://github.com/18F/s3-resource-simple/pull/14, adds an option to the `params` to skip any downloading on a `put` - there's usually no need for this as it's immediately discarded and results in additional bandwidth.

Example usage:
```
resources:
- name: <resource name>
  type: <resource type name>
  source:
    access_key_id: {{aws-access-key}}
    secret_access_key: {{aws-secret-key}}
    bucket: {{aws-bucket}}
jobs:
- name: <job name>
  plan:
  - put: <resource name>
     params:
       skip_download: true
```