### PR TITLE
Prevent AWS env keys being set to 'null' of not specified

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -10,8 +10,8 @@ bucket=$(echo "$payload" | jq -r '.source.bucket')
 prefix="$(echo "$payload" | jq -r '.source.path // ""')"
 
 # export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // ""')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // ""')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then

--- a/assets/in
+++ b/assets/in
@@ -21,8 +21,8 @@ path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 
 # export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // ""')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key // ""')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then

--- a/assets/out
+++ b/assets/out
@@ -21,8 +21,8 @@ path=$(echo "$payload" | jq -r '.source.path // ""')
 options=$(echo "$payload" | jq -r '.source.options // [] | join(" ")')
 
 # export for `aws` cli
-AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
-AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key')
+AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id // ""')
+AWS_SECRET_ACCESS_KEY=$(echo "$payload" | jq -r '.source.secret_access_key //""')
 
 # Due to precedence rules, must be unset to support AWS IAM Roles.
 if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then


### PR DESCRIPTION
If the resource's access_key_id and secret_access_key are not set then jq defaults the string to be 'null' which results in:
export AWS_ACCESS_KEY_ID=null
export AWS_SECRET_ACCESS_KEY=null
When this happens aws cli doesn't query for IAM roles and access is denied.