### PR TITLE
Fixed options Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ we can upload _only_ the `results` subdirectory by using the following `options`
 
 ```yaml
 options:
-  - "--exclude '*'",
-  - "--include 'results/*'"
+- "--exclude '*'"
+- "--include 'results/*'"
 ```
 
 ### Region


### PR DESCRIPTION
The exclude and include keys shouldn't be indented.

There shouldn't be comma after exclude.

After making these changes myself, my pipeline configuration passes fly validation and works properly.