### PR TITLE
fix installing pip and using pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,14 @@ RUN apk update && apk upgrade
 # sqlite is not used, and has vulns
 RUN apk del sqlite
 RUN apk add python3
+RUN apk add py3-pip
+
 
 # get the latest straight from the source - upstream version has known vulns
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
 	&& mv jq-linux64 /usr/local/bin/jq \
 	&& chmod +x /usr/local/bin/jq
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade awscli
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade awscli
 
 ADD assets/ /opt/resource/


### PR DESCRIPTION
# proposed changes

- install pip directly - alpine no longer includes it in the python package
- call pip the preferred way

# security implications
None